### PR TITLE
Update travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 # Based on the "trust" template v0.1.1
 # https://github.com/japaric/trust/tree/v0.1.1
 
-dist: trusty
+dist: xenial
 language: rust
 services: docker
-sudo: required
 
 env:
   global:


### PR DESCRIPTION
The `trusty` dist is now deprecated in favour of `xenial`. And the
`sudo` entry is deprecated as well. The container builds are no more
and every Linux build runs on a full VM with sudo enabled.