### PR TITLE
Make the build fail

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -343,5 +343,6 @@ fn process_cli_and_run_game() {
 fn process_cli_and_run_game() {}
 
 fn main() {
+    lol
     process_cli_and_run_game();
 }


### PR DESCRIPTION
Another one to test if the CI's right now.

Ideally, all CI jobs (which are now all green) should be red on this PR.