### PR TITLE
Fix the CI builds

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code, unused_macros)]
+
 use std::fmt;
 
 #[derive(Debug)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,11 +3,9 @@
     unsafe_code,
     rust_2018_idioms,
     rust_2018_compatibility,
-    unused,
     unused_extern_crates,
     nonstandard_style,
     future_incompatible,
-    missing_copy_implementations,
     missing_debug_implementations,
     clippy::explicit_iter_loop,
     clippy::cast_lossless,
@@ -20,6 +18,7 @@
     clippy::unseparated_literal_suffix,
     clippy::doc_markdown
 )]
+#![warn(missing_copy_implementations)]
 #![allow(
     clippy::identity_op,
     clippy::wildcard_imports,


### PR DESCRIPTION
Some of the warnings (`unused` and `missing_copy_implementations`) we
were denying were breaking our builds due to conditional compilation
etc.

This keeps the warnings enabled, but makes them warn instead of abort.