### PR TITLE
Add more granular checks to the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,21 +47,35 @@ jobs:
     - uses: actions/checkout@v2
     - name: Install build-time dependencies
       run: ${{ matrix.platform.build_time_dependencies }}
+    # A regular cargo check: fail fast if something is wrong
+    - name: Check default code syntax
+      run: cargo check
+    # Cargo check for the prod features to catch compilation issues quickly
+    - name: Check production code syntax
+      run: >
+        cargo check --no-default-features
+        --features "prod ${{ matrix.platform.extra_features }}"
     - name: Build
       run: cargo build --verbose
     - name: Run tests
       run: cargo test --verbose
+    - name: Check for warnings
+      run: |
+        cargo check
+        cargo clippy
+      env:
+        RUSTFLAGS: -D warnings
+    - name: Build the release
+      run: >
+        cargo build --verbose --release --no-default-features
+        --features "prod ${{ matrix.platform.extra_features }}"
+      if: ${{ env.HAS_SECRETS == 'true' }}
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         aws-region: ${{ secrets.AWS_REGION_NAME }}
-      if: ${{ env.HAS_SECRETS == 'true' }}
-    - name: Build the release
-      run: >
-        cargo build --verbose --release --no-default-features
-        --features "prod ${{ matrix.platform.extra_features }}"
       if: ${{ env.HAS_SECRETS == 'true' }}
     - name: Package and upload the release
       run: |


### PR DESCRIPTION
This adds a regular cargo check, then a cargo check with the expected
features and finally a check+clippy run that denies all warnings.

This means that significant issues (syntax error, build error, test
error) will surface quickly and that we will keep our code
warning-free going forward.

If the warnings are too problematic, I'll just take them out later but
I'd rather maintain a set of warnings I care about than not having any
checks at all.

But I categorically do not want a blanked "deny(warnings)" statement
in the code itself because it massively slows down development and
refactoring and is a major pain in the arse.