### PR TITLE
Fix some clippy lints

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -122,7 +122,7 @@ fn save_out_dir(cargo_manifest_dir: &str, out_dir: &Path) -> Result<(), Box<dyn 
 
 fn current_git_commit() -> Option<String> {
     Command::new("git")
-        .args(&["rev-parse", "HEAD"])
+        .args(["rev-parse", "HEAD"])
         .output()
         .ok()
         .and_then(|output| String::from_utf8(output.stdout).ok())
@@ -208,13 +208,13 @@ fn main() {
         writeln!(
             lookup_table_contents,
             "pub const TILEMAP_TEXTURE_WIDTH: u32 = {};",
-            width as u32
+            width
         );
 
         writeln!(
             lookup_table_contents,
             "pub const TILEMAP_TEXTURE_HEIGHT: u32 = {};",
-            height as u32
+            height
         );
     }
 
@@ -283,7 +283,7 @@ fn main() {
         // biggest glyphs first.
         let all_sizes = {
             let mut sizes: Vec<_> = tile_sizes.into();
-            sizes.extend(&text_sizes);
+            sizes.extend(text_sizes);
             sizes.sort_by(|a, b| b.cmp(a));
             sizes
         };
@@ -351,7 +351,7 @@ fn main() {
                     let y = y as i32 + bb.min.y;
                     // There's still a possibility that the glyph clips
                     // the boundaries of the bitmap
-                    if x >= 0 && x < texture_width as i32 && y >= 0 && y < texture_height as i32 {
+                    if x >= 0 && x < texture_width && y >= 0 && y < texture_height {
                         let alpha = (v * 255.0) as u8;
                         let pixel = Rgba([255, 255, 255, alpha]);
                         textmap.put_pixel(x as u32, y as u32, pixel);

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -1,4 +1,4 @@
-use crate::{random::Random, util};
+use crate::random::Random;
 
 use std::time::Duration;
 
@@ -149,12 +149,12 @@ impl Audio {
     }
 
     pub fn set_background_volume(&mut self, volume: f32) {
-        let volume = util::clampf(0.0, volume, 1.0);
+        let volume = volume.clamp(0.0, 1.0);
         self.background_sound_queue.set_volume(volume);
     }
 
     pub fn set_effects_volume(&mut self, volume: f32) {
-        let volume = util::clampf(0.0, volume, 1.0);
+        let volume = volume.clamp(0.0, 1.0);
         for queue in &mut self.sound_effect_queue {
             queue.set_volume(volume);
         }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -5,7 +5,6 @@ use crate::{
     graphic::{self, Graphic, TILE_SIZE},
     point::Point,
     rect::Rectangle,
-    util,
 };
 
 use std::fmt;
@@ -658,7 +657,7 @@ impl Display {
     /// Set the value (RGBA) to fade the screen with.
     /// Unlike alpha, the `fade` argument is inverted: 1.0 means no fade, 0.0 means fully faded.
     pub fn set_fade(&mut self, color: Color, fade: f32) {
-        let fade = util::clampf(0.0, fade, 1.0);
+        let fade = fade.clamp(0.0, 1.0);
         let fade = (fade * 255.0) as u8;
         self.fade = color.alpha(255 - fade);
     }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -168,7 +168,7 @@ impl VertexStore for Vec<Vertex> {
 
 impl VertexStore for Vec<f32> {
     fn push(&mut self, vertex: Vertex) {
-        self.extend(&vertex.to_f32_array())
+        self.extend(vertex.to_f32_array())
     }
 
     fn count(&self) -> usize {
@@ -531,16 +531,8 @@ impl Display {
         // Without it, the partial tiles would not appear.
         let display_size = {
             let size = screen_size_px / tile_size;
-            let extra_x = if size.x * tile_size < screen_size_px.x {
-                1
-            } else {
-                0
-            };
-            let extra_y = if size.y * tile_size < screen_size_px.y {
-                1
-            } else {
-                0
-            };
+            let extra_x = i32::from(size.x * tile_size < screen_size_px.x);
+            let extra_y = i32::from(size.y * tile_size < screen_size_px.y);
             size + Point::new(extra_x, extra_y)
         };
         let padding = Point::from_i32(1);

--- a/src/engine/glutin.rs
+++ b/src/engine/glutin.rs
@@ -114,7 +114,7 @@ fn get_current_monitor(monitors: &[MonitorHandle], window_pos: Point) -> Option<
     for monitor in monitors {
         let monitor_pos = {
             let pos = monitor.position();
-            Point::new(pos.x as i32, pos.y as i32)
+            Point::new(pos.x, pos.y)
         };
         let monitor_dimensions = {
             let dim = monitor.size();
@@ -287,7 +287,7 @@ where
     let mut window_pos = context
         .window()
         .outer_position()
-        .map(|p| Point::new(p.x as i32, p.y as i32))
+        .map(|p| Point::new(p.x, p.y))
         .unwrap_or_default();
     log::info!("Window pos: {:?}", window_pos);
     let mut pre_fullscreen_window_pos = window_pos;
@@ -337,8 +337,8 @@ monitor ID: {:?}. Ignoring this request.",
 
                     context.resize(size);
                     loop_state.handle_window_size_changed(
-                        logical_size.width as i32,
-                        logical_size.height as i32,
+                        logical_size.width,
+                        logical_size.height,
                     );
                 }
 
@@ -357,8 +357,8 @@ monitor ID: {:?}. Ignoring this request.",
                             loop_state.current_frame_id,
                             new_pos
                         );
-                        window_pos.x = new_pos.x as i32;
-                        window_pos.y = new_pos.y as i32;
+                        window_pos.x = new_pos.x;
+                        window_pos.y = new_pos.y;
                         current_monitor = get_current_monitor(&monitors, window_pos);
                         log::debug!(
                             "Current monitor: {:?}, pos: {:?}, size: {:?}",
@@ -432,7 +432,7 @@ monitor ID: {:?}. Ignoring this request.",
                 WindowEvent::MouseWheel { delta, .. } => {
                     use MouseScrollDelta::*;
                     match delta {
-                        LineDelta(x, y) => loop_state.mouse.scroll_delta = [x as f32, y as f32],
+                        LineDelta(x, y) => loop_state.mouse.scroll_delta = [x, y],
                         PixelDelta(PhysicalPosition { x: x_px, y: y_px }) => {
                             let line_height_px = loop_state.settings.text_size as f32;
                             loop_state.mouse.scroll_delta =

--- a/src/engine/loop_state.rs
+++ b/src/engine/loop_state.rs
@@ -6,7 +6,6 @@ use crate::{
     point::Point,
     settings::{Settings, Store as SettingsStore},
     state::State,
-    util,
 };
 
 use std::{convert::TryInto, sync::Arc, time::Duration};
@@ -440,8 +439,8 @@ impl LoopState {
     pub fn update_mouse_position(&mut self, dpi: f64, window_px_x: i32, window_px_y: i32) {
         let display_info = self.display_info(dpi);
 
-        let x = util::clamp(0, window_px_x, display_info.window_size_px[0] as i32 - 1);
-        let y = util::clamp(0, window_px_y, display_info.window_size_px[1] as i32 - 1);
+        let x = window_px_x.clamp(0, display_info.window_size_px[0] as i32 - 1);
+        let y = window_px_y.clamp(0, display_info.window_size_px[1] as i32 - 1);
 
         self.mouse.screen_pos = Point { x, y };
 

--- a/src/engine/loop_state.rs
+++ b/src/engine/loop_state.rs
@@ -372,7 +372,7 @@ impl LoopState {
     }
 
     pub fn change_tilesize_px(&mut self, new_tilesize_px: i32) {
-        if crate::engine::AVAILABLE_TILE_SIZES.contains(&(new_tilesize_px as i32)) {
+        if crate::engine::AVAILABLE_TILE_SIZES.contains(&new_tilesize_px) {
             log::info!(
                 "Changing tilesize from {} to {}",
                 self.display.tile_size,
@@ -395,7 +395,7 @@ impl LoopState {
     }
 
     pub fn change_text_size_px(&mut self, new_text_size_px: i32) {
-        if crate::engine::AVAILABLE_TEXT_SIZES.contains(&(new_text_size_px as i32)) {
+        if crate::engine::AVAILABLE_TEXT_SIZES.contains(&new_text_size_px) {
             log::info!(
                 "Changing text from {} to {}",
                 self.display.text_size,

--- a/src/pathfinding.rs
+++ b/src/pathfinding.rs
@@ -287,15 +287,15 @@ mod test {
             for c in line.chars() {
                 if c == 's' {
                     start = Point {
-                        x: x as i32,
-                        y: y as i32,
+                        x,
+                        y,
                     };
                 }
 
                 if c == 'd' {
                     destination = Point {
-                        x: x as i32,
-                        y: y as i32,
+                        x,
+                        y,
                     };
                 }
 
@@ -308,8 +308,8 @@ mod test {
                     _ => unreachable!(),
                 };
                 let pos = Point {
-                    x: x as i32,
-                    y: y as i32,
+                    x,
+                    y,
                 };
                 if let Some(cell) = world.cell_mut(pos) {
                     cell.tile = Tile::new(tile_kind);

--- a/src/ranged_int.rs
+++ b/src/ranged_int.rs
@@ -131,13 +131,7 @@ impl Add<Rational32> for Ranged {
         match self.val.to_integer().checked_add(other.to_integer()) {
             Some(_) => {
                 let v = self.val + other;
-                let new_val = if v > self.max {
-                    self.max
-                } else if v < self.min {
-                    self.min
-                } else {
-                    v
-                };
+                let new_val = v.clamp(self.min, self.max);
                 Ranged::new(new_val, range)
             }
             None => {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,4 +1,4 @@
-use crate::{engine, palette, state, util};
+use crate::{engine, palette, state};
 
 use serde::{Deserialize, Serialize};
 
@@ -488,14 +488,14 @@ impl Store for FileSystemStore {
 
         match self.toml[BACKGROUND_VOLUME].as_float() {
             Some(volume) => {
-                settings.background_volume = util::clampf(0.0, volume as f32, 1.0);
+                settings.background_volume = volume.clamp(0.0, 1.0) as f32;
             }
             // toml_edit uses `f64.as_string()` which outputs e.g.
             // `1.0` as `1`. This then gets parsed here as integer not
             // float so we need to handle that case separately.
             None => match self.toml[BACKGROUND_VOLUME].as_integer() {
                 Some(volume) => {
-                    settings.background_volume = util::clampf(0.0, volume as f32, 1.0);
+                    settings.background_volume = volume.clamp(0, 1) as f32;
                 }
                 None => log::error!("Settings: missing `{}` entry.", BACKGROUND_VOLUME),
             },
@@ -503,11 +503,11 @@ impl Store for FileSystemStore {
 
         match self.toml[SOUND_VOLUME].as_float() {
             Some(volume) => {
-                settings.sound_volume = util::clampf(0.0, volume as f32, 1.0);
+                settings.sound_volume = volume.clamp(0.0, 1.0) as f32;
             }
             None => match self.toml[SOUND_VOLUME].as_integer() {
                 Some(volume) => {
-                    settings.sound_volume = util::clampf(0.0, volume as f32, 1.0);
+                    settings.sound_volume = volume.clamp(0, 1) as f32;
                 }
                 None => log::error!("Settings: missing `{}` entry.", SOUND_VOLUME),
             },

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -275,7 +275,7 @@ pub fn progress_bar(
 ) {
     use egui::paint::Shape;
 
-    let percent = crate::util::clampf(0.0, percent, 1.0);
+    let percent = percent.clamp(0.0, 1.0);
     let background_rect = Shape::rect_filled(
         Rect::from_min_size(top_left, [width, height].into()),
         0.0,

--- a/src/util.rs
+++ b/src/util.rs
@@ -19,34 +19,12 @@ pub fn duration_sub_or_zero(duration: Duration, other: Duration) -> Duration {
         .unwrap_or_else(|| Duration::new(0, 0))
 }
 
-/// If `val` is outside the `min` / `max` limits, set it to the edge value.
-pub fn clamp(min: i32, val: i32, max: i32) -> i32 {
-    if val < min {
-        min
-    } else if val > max {
-        max
-    } else {
-        val
-    }
-}
-
-/// If `val` is outside the `min` / `max` limits, set it to the edge value.
-pub fn clampf(min: f32, val: f32, max: f32) -> f32 {
-    if val < min {
-        min
-    } else if val > max {
-        max
-    } else {
-        val
-    }
-}
-
 /// Take a floating value from <0.0, 1.0> and get it through a sine
 /// curve processing. The result is <0.0, 1.0> but represented as part
 /// of the sine curve, not a line.
 pub fn sine_curve(percentage: f32) -> f32 {
     use std::f32::consts;
-    let val = clampf(0.0, percentage, 1.0);
+    let val = percentage.clamp(0.0, 1.0);
     let rad = val * consts::PI / 2.0;
     rad.sin()
 }

--- a/src/world.rs
+++ b/src/world.rs
@@ -506,7 +506,7 @@ impl World {
                 self.nearest_dose(world_pos, 5)
                     .map_or(false, |(dose_pos, dose)| {
                         world_pos.tile_distance(dose_pos)
-                            < formula::player_resist_radius(dose.irresistible, player_will) as i32
+                            < formula::player_resist_radius(dose.irresistible, player_will)
                     })
             } else {
                 false


### PR DESCRIPTION
Just a few minor fixes.

I removed the _internal_ implementation of `clamp`, replacing its usage with the one from `std`. This is available since Rust 1.50, so I thing it should not be a problem.
