### PR TITLE
Disable inventory focus on mouse click

### DIFF
--- a/src/game.rs
+++ b/src/game.rs
@@ -658,6 +658,10 @@ fn process_game(
             process_keys(&mut state.keys, &mut state.commands);
         }
 
+        if state.mouse.left_clicked || state.mouse.right_clicked {
+            state.inventory_focused = false;
+        }
+
         if state.mouse.left_clicked || state.commands.front() == Some(&Command::WalkPath) {
             state.path_walking_timer.finish();
         } else {


### PR DESCRIPTION
If the inventory/sidebar has the keyboard focus (because the player pressed the `I` key), it gets dismissed again if the player clicks the mouse.

This feels much more intuitive and in line with what I'm used to for these "modal" panels than just keeping the focus on there even if the mouse moved the character or something in the meantime.