### PR TITLE
package-release: use zip_add_*_from_path

### DIFF
--- a/bin/src/bin/package-release.rs
+++ b/bin/src/bin/package-release.rs
@@ -227,11 +227,8 @@ fn main() -> anyhow::Result<()> {
             let mut zip = ZipWriter::new(zip_file);
 
             zip.add_directory(archive_directory_name, SimpleFileOptions::default())?;
-            zip.add_directory(
-                Path::new(archive_directory_name)
-                    .join("icons")
-                    .to_str()
-                    .unwrap(),
+            zip.add_directory_from_path(
+                Path::new(archive_directory_name).join("icons"),
                 SimpleFileOptions::default(),
             )?;
 
@@ -263,7 +260,7 @@ fn main() -> anyhow::Result<()> {
                     };
                     let options = options.unix_permissions(permissions);
 
-                    zip.start_file(destination_path.to_str().unwrap(), options)?;
+                    zip.start_file_from_path(destination_path, options)?;
                     let mut contents = vec![];
                     let mut f = File::open(entry.path())?;
                     f.read_to_end(&mut contents)?;


### PR DESCRIPTION
The Windows packages were producing files with literal slashes in them. The macos ones were fine. Not sure what exactly is going on, but since the methods actually have methods that accept a Path directly, we should use that anyway.

Shorter, cleaner, safer code.

And presumably will fix this issue.