### PR TITLE
make: add `steam-deck` target

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM debian:stable-20240812-slim
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+ENV NO_COLOR=true
+
+ENV RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH=/usr/local/cargo/bin:$PATH \
+    RUST_VERSION=1.80.1
+
+RUN set -eux; \
+    apt update; \
+    apt install -y pkg-config curl libasound2-dev libudev-dev build-essential cmake libfontconfig-dev; \
+    rm -rf /var/lib/apt/lists/*; \
+    curl -LO https://static.rust-lang.org/rustup/archive/1.27.1/x86_64-unknown-linux-gnu/rustup-init; \
+    chmod +x rustup-init; \
+    ./rustup-init -y --no-modify-path --profile minimal --default-toolchain 1.80.1 --default-host x86_64-unknown-linux-gnu; \
+    rm rustup-init; \
+    chmod -R a+w $RUSTUP_HOME $CARGO_HOME; \
+    rustup --version; \
+    cargo --version; \
+    rustc --version;

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,10 @@ package-release:
 	cargo run --manifest-path bin/Cargo.toml --bin package-release
 .PHONY: package-release
 
+steam-deck:
+	bin/container-build.sh
+.PHONY: steam-deck
+
 replay:
 	cargo run -- `find replays -type f -name 'replay-*' | sort | tail -n 1`
 .PHONY: replay

--- a/bin/container-build.sh
+++ b/bin/container-build.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -euo pipefail
+
+if [ -z "$(podman images --quiet dose-response-builder)" ]; then
+    podman build -t dose-response-builder .
+fi
+
+podman run -i -t --rm -v .:/app dose-response-builder bash -c 'cd app && cargo build --release --target-dir target/container-build'
+
+printf "Build created in:\ntarget/container-build/release/dose-response\n"


### PR DESCRIPTION
This will build the game in a container of a Debian release old enough that its glibc version is supported on the Steam Deck.

We use `podman` to actually create the build in the Debian image.

Seems to be working really solidly, actually.

Haven't tested the result on the deck yet, but at least the build pipeline seems sound.