### PR TITLE
Display build info in the log and Help screen

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -140,6 +140,35 @@ fn main() {
         env::var("TARGET").unwrap_or_default()
     );
 
+    println!(
+        "cargo:rustc-env=DR_CARGO_PROFILE={}",
+        env::var("PROFILE").unwrap_or_default()
+    );
+
+    println!(
+        "cargo:rustc-env=DR_CARGO_OPT_LEVEL={}",
+        env::var("OPT_LEVEL").unwrap_or_default()
+    );
+
+    let features = std::env::vars()
+        .filter(|(k, _v)| k.starts_with("CARGO_FEATURE_"))
+        .map(|(k, _v)| k.trim_start_matches("CARGO_FEATURE_").to_string())
+        .collect::<Vec<_>>()
+        .join(":");
+
+    println!("cargo:rustc-env=DR_FEATURES={}", features);
+
+    let configs = std::env::vars()
+        .filter(|(k, _v)| k.starts_with("CARGO_CFG_"))
+        .map(|(k, v)| {
+            let k = k.trim_start_matches("CARGO_CFG_").to_string();
+            format!("{k}={v}")
+        })
+        .collect::<Vec<_>>()
+        .join(":");
+
+    println!("cargo:rustc-env=DR_CONFIGS={}", configs);
+
     let out_dir = env::var("OUT_DIR").unwrap();
     let out_dir = Path::new(&out_dir);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -224,6 +224,11 @@ pub fn run() -> Result<(), Box<dyn std::error::Error>> {
         log::info!("Target triple: {}", target_triple);
     }
 
+    log::info!("Build profile: {}", metadata::PROFILE);
+    log::info!("Optimisation level: {}", metadata::OPT_LEVEL);
+    log::info!("Build features: {}", metadata::FEATURES);
+    log::info!("Build configs: {}", metadata::CONFIGS);
+
     log::info!(
         "Available text sizes: {:?}",
         crate::engine::AVAILABLE_TEXT_SIZES

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -7,3 +7,7 @@ pub const TITLE: &str = "Dose Response";
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 pub const VERSION_MAJOR: &str = env!("CARGO_PKG_VERSION_MAJOR");
 pub const VERSION_MINOR: &str = env!("CARGO_PKG_VERSION_MINOR");
+pub const PROFILE: &str = env!("DR_CARGO_PROFILE");
+pub const OPT_LEVEL: &str = env!("DR_CARGO_OPT_LEVEL");
+pub const FEATURES: &str = env!("DR_FEATURES");
+pub const CONFIGS: &str = env!("DR_CONFIGS");

--- a/src/windows/help.rs
+++ b/src/windows/help.rs
@@ -229,7 +229,7 @@ pub fn process(
                 .show(ui, |ui| {
                     // NOTE: HACK: the 7px value hides the scrollbar on contents that doesn't overflow.
                     ui.set_min_height(window_size_px[1] - 7.0);
-                    let copyright = format!("Copyright 2013-2021 {}", crate::metadata::AUTHORS);
+                    let copyright = format!("Copyright 2013-2024 {}", crate::metadata::AUTHORS);
                     match state.current_help_window {
                         Page::DoseResponse => {
                             ui.label(OVERVIEW);

--- a/src/windows/help.rs
+++ b/src/windows/help.rs
@@ -310,10 +310,7 @@ pub fn process(
                                 format!("Homepage: {}", crate::metadata::HOMEPAGE),
                                 crate::metadata::HOMEPAGE,
                             );
-
-                            if !crate::metadata::GIT_HASH.trim().is_empty() {
-                                ui.label(format!("Git commit: {}", crate::metadata::GIT_HASH));
-                            }
+                            ui.label(copyright);
 
                             ui.label("");
                             ui.label(CODE_LICENSE_BLOCK);
@@ -321,7 +318,16 @@ pub fn process(
                             ui.label("");
                             ui.label(THIRD_PARTY_CODE_LICENSE);
                             ui.label("");
-                            ui.label(copyright);
+
+                            if !crate::metadata::GIT_HASH.trim().is_empty() {
+                                ui.label(format!("Git commit: {}", crate::metadata::GIT_HASH));
+                            }
+
+			    let features = crate::metadata::FEATURES.replace(":", "\n* ");
+
+			    let configs = crate::metadata::CONFIGS.replace(":", "\n* ");
+
+			    ui.label(format!("Build profile: {}\nOptimisation level: {}\n\nBuild features: \n* {features}\n\nBuild configs: \n* {configs}\n\n", crate::metadata::PROFILE, crate::metadata::OPT_LEVEL));
                         }
                     };
                 });


### PR DESCRIPTION
This should let us be able to figure out how exactly a given binary was built. Either for log reports or to double-check that it's running on the expected platform, release mode or features.