### PR TITLE
Make the replay even faster

### DIFF
--- a/src/engine/loop_state.rs
+++ b/src/engine/loop_state.rs
@@ -343,6 +343,10 @@ impl LoopState {
             &mut self.audio,
         );
 
+        let skipping = std::matches!(update_result, RunningState::Skip);
+        if skipping {
+            log::debug!("Skipping no-op frames...");
+        }
         while std::matches!(update_result, RunningState::Skip) {
             update_result = crate::game::update(
                 &mut self.game_state,
@@ -361,6 +365,9 @@ impl LoopState {
                 &mut self.display,
                 &mut self.audio,
             );
+        }
+        if skipping {
+            log::debug!("Finished the frame skip");
         }
 
         if previous_palette != self.settings.palette() {

--- a/src/formula.rs
+++ b/src/formula.rs
@@ -6,6 +6,7 @@ use crate::{
     point::Point,
     random::Random,
     ranged_int::{InclusiveRange, Ranged},
+    rect::Rectangle,
     state::Challenge,
 };
 
@@ -326,4 +327,8 @@ pub fn depression_max_ap(challenge: Challenge) -> i32 {
     } else {
         1
     }
+}
+
+pub fn simulation_area(player_pos: Point) -> Rectangle {
+    Rectangle::center(player_pos, Point::from_i32(SIMULATION_RADIUS))
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -619,12 +619,6 @@ Reason: '{}'.",
         self.screen_left_top_corner() + self.mouse.tile_pos
     }
 
-    pub fn equivalent_to(&self, other: &State) -> bool {
-        self.player == other.player
-            && self.world == other.world
-            && self.window_stack == other.window_stack
-    }
-
     pub fn try_clone(&self) -> Option<Self> {
         // TODO: this is a poor man's `Clone`. Just implement `Clone` on `State`?
         // And then do the same at the bottom of the function too.


### PR DESCRIPTION
Now we skip the state cloning and comparing (where we actually do process every single frame -- just not render it).

Instead, we set out a few rules that result in the frame being a no-op and when we hit those, we'll just skip the rest of the processing right there and then. So no player or monster processing happens.

And I feel the `State` cloning via serialising & deserialising was probably slowing things too.

With this, the replays feel pretty much as fast as they possibly could be. And they're replaying all the four recorded ones (including victory) flawlessly.

There is a bit of a hack we had to do to stop the victory one from crashing: when a NPC accompanies a player, the bonus will be set at a subsequent frame for whatever reason. And the frame where the Victory "bonus" is set looks otherwise as a frame we should skip.

This is because the whole victory condition was kinda hacked on top of the existing bonus system.

I don't want to change that because it would invalidate the replay and honestly I just don't care now.

But it means we're piling another hack on top of this bonus-laden hack.

Whatever. It works and I honestly don't expect that many new changes to the game.