### PR TITLE
Add an `e2e-tests` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,10 @@ steam-deck:
 	bin/container-build.sh
 .PHONY: steam-deck
 
+e2e-tests:
+	bin/e2e-tests.sh
+.PHONY: e2e-tests
+
 replay:
 	cargo run -- `find replays -type f -name 'replay-*' | sort | tail -n 1`
 .PHONY: replay

--- a/bin/e2e-tests.sh
+++ b/bin/e2e-tests.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+for f in replays/e2e-tests/*; do
+    cargo run --release -- --exit-after --replay-full-speed "$f"
+done

--- a/src/game.rs
+++ b/src/game.rs
@@ -253,7 +253,7 @@ pub fn update(
     }
 
     // Quit the game when Q is pressed or on replay and requested
-    if (!state.player.alive() && state.exit_after)
+    if ((state.side == Side::Victory || !state.player.alive()) && state.exit_after)
         || (state.replay
             && state.exit_after
             && (state.inputs.is_empty()


### PR DESCRIPTION
You can now run `make e2e-tests` and it will run all the recorded replays in `replays/e2e-tests`. There are none checked into the repo because they're massive (hundreds of megs or even gigs).

Maybe we'll be able to support compressed / smaller replay files later but for now they're just too big.

An ultimate goal is to run this as part of the CI, but we're not there yet -- for that we'll need to support headless replays.