### PR TITLE
Improve scrolling in the Help screen

### DIFF
--- a/src/engine/loop_state.rs
+++ b/src/engine/loop_state.rs
@@ -318,6 +318,7 @@ impl LoopState {
         let tile_width_px = self.settings.tile_size;
         let text_width_px = self.settings.text_size;
         self.egui_context.begin_frame(self.egui_raw_input());
+        self.game_state.keyboard_scroll_delta = [0.0, 0.0];
 
         if let Some(gilrs) = self.gilrs.as_mut() {
             gamepad::process_gamepad_events(gilrs, &mut self.gamepad, dt)
@@ -395,6 +396,17 @@ impl LoopState {
         let mouse = self.game_state.mouse;
         let mouse_pos = [mouse.screen_pos.x as f32, mouse.screen_pos.y as f32].into();
         let mut events = vec![Event::PointerMoved(mouse_pos)];
+
+        let scroll_delta = if mouse.scroll_delta == [0.0, 0.0] {
+            self.game_state.keyboard_scroll_delta
+        } else {
+            [
+                mouse.scroll_delta[0] * text_size,
+                mouse.scroll_delta[1] * text_size,
+            ]
+        };
+        let scroll_delta = scroll_delta.into();
+
         if mouse.left_clicked {
             events.push(Event::PointerButton {
                 pos: mouse_pos,
@@ -410,11 +422,7 @@ impl LoopState {
             });
         }
         RawInput {
-            scroll_delta: [
-                mouse.scroll_delta[0] * text_size,
-                mouse.scroll_delta[1] * text_size,
-            ]
-            .into(),
+            scroll_delta,
             screen_rect: Some(egui::Rect::from_min_size(
                 Default::default(),
                 [

--- a/src/state.rs
+++ b/src/state.rs
@@ -252,7 +252,7 @@ pub struct State {
     pub current_help_window: windows::help::Page,
     pub inventory_focused: bool,
     /// Used for help contents pagination: which line should we start showing.
-    pub help_starting_line: i32,
+    pub help_starting_line: Option<i32>,
 
     /// Whether we should push the Endscreen window and uncover the
     /// map during the transition from screen fade out to fade in
@@ -369,7 +369,7 @@ impl State {
             selected_sidebar_action: None,
             current_help_window: windows::help::Page::DoseResponse,
             inventory_focused: false,
-            help_starting_line: 0,
+            help_starting_line: None,
             show_endscreen_and_uncover_map_during_fadein: false,
             uncovered_map: false,
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -251,8 +251,8 @@ pub struct State {
     pub selected_sidebar_action: Option<windows::sidebar::Action>,
     pub current_help_window: windows::help::Page,
     pub inventory_focused: bool,
-    /// Used for help contents pagination: which line should we start showing.
-    pub help_starting_line: Option<i32>,
+    /// Used for help contents pagination: how much are we scrolling by
+    pub keyboard_scroll_delta: [f32; 2],
 
     /// Whether we should push the Endscreen window and uncover the
     /// map during the transition from screen fade out to fade in
@@ -369,7 +369,7 @@ impl State {
             selected_sidebar_action: None,
             current_help_window: windows::help::Page::DoseResponse,
             inventory_focused: false,
-            help_starting_line: None,
+            keyboard_scroll_delta: [0.0, 0.0],
             show_endscreen_and_uncover_map_during_fadein: false,
             uncovered_map: false,
 

--- a/src/windows/help.rs
+++ b/src/windows/help.rs
@@ -237,118 +237,118 @@ pub fn process(
 		state.help_starting_line = None;
 		scroll_area
 	    };
-		scroll_area.show(ui, |ui| {
-                    // NOTE: HACK: the 7px value hides the scrollbar on contents that doesn't overflow.
-                    ui.set_min_height(window_size_px[1] - 7.0);
-                    let copyright = format!("Copyright 2013-2024 {}", crate::metadata::AUTHORS);
-                    match state.current_help_window {
-                        Page::DoseResponse => {
-                            ui.label(OVERVIEW);
-                        }
+	    scroll_area.show(ui, |ui| {
+                // NOTE: HACK: the 7px value hides the scrollbar on contents that doesn't overflow.
+                ui.set_min_height(window_size_px[1] - 7.0);
+                let copyright = format!("Copyright 2013-2024 {}", crate::metadata::AUTHORS);
+                match state.current_help_window {
+                    Page::DoseResponse => {
+                        ui.label(OVERVIEW);
+                    }
 
-                        Page::Controls => {
-                            ui.label(CONTROLS_HEADER);
-                            ui.label(NUMPAD_TEXT);
-                            ui.label("");
-                            // NOTE: this is a hack for not having a
-                            // way to center a label but it works:
-                            ui.columns(1, |c| {
-                                c[0].with_layout(
-                                    egui::Layout::top_down(egui::Align::Center),
-                                    |ui| {
-                                        ui.label(NUMPAD_CONTROLS);
-                                    },
-                                );
-                            });
-                            ui.label(ARROW_TEXT);
-                            ui.label("");
-                            ui.columns(1, |c| {
-                                c[0].with_layout(
-                                    egui::Layout::top_down(egui::Align::Center),
-                                    |ui| {
-                                        ui.label(ARROW_CONTROLS);
-                                    },
-                                );
-                            });
-                            ui.label(MODIFIER_KEYS);
-                            ui.label("");
-                            ui.label(VI_KEYS_TEXT);
-                            ui.label("");
-                            ui.columns(1, |c| {
-                                c[0].with_layout(
-                                    egui::Layout::top_down(egui::Align::Center),
-                                    |ui| {
-                                        ui.label(VI_KEYS_CONTROLS);
-                                    },
-                                );
-                            });
-                            ui.label(CONTROLS_FOOTER);
-                            ui.label("");
-                            ui.label(CONTROLLER);
-                        }
-
-                        Page::HowToPlay => {
-                            ui.label(HOW_TO_PLAY);
-                        }
-
-                        Page::Legend => {
-                            ui.label(LEGEND);
-                        }
-
-                        Page::Credits => {
-                            ui.hyperlink_to(CREDITS_DEV, TOMAS_URL);
-                            ui.label(copyright);
-                            ui.label(CODE_LICENSE_ONELINE);
-                            ui.label("");
-                            ui.hyperlink_to(CREDITS_TILES, VEXED_URL);
-                            ui.label(TILES_LICENSE);
-                            ui.label("");
-                            ui.hyperlink_to(CREDITS_FONT, MONONOKI_URL);
-                            ui.label(FONT_LICENSE);
-                            ui.label("");
-                            ui.label(CREDITS_MUSIC);
-                        }
-
-                        Page::About => {
-                            let version = format!(
-                                "{} version: {}",
-                                crate::metadata::TITLE,
-                                crate::metadata::VERSION
+                    Page::Controls => {
+                        ui.label(CONTROLS_HEADER);
+                        ui.label(NUMPAD_TEXT);
+                        ui.label("");
+                        // NOTE: this is a hack for not having a
+                        // way to center a label but it works:
+                        ui.columns(1, |c| {
+                            c[0].with_layout(
+                                egui::Layout::top_down(egui::Align::Center),
+                                |ui| {
+                                    ui.label(NUMPAD_CONTROLS);
+                                },
                             );
-
-                            ui.label(version);
-                            ui.hyperlink_to(
-                                format!("Homepage: {}", crate::metadata::HOMEPAGE),
-                                crate::metadata::HOMEPAGE,
+                        });
+                        ui.label(ARROW_TEXT);
+                        ui.label("");
+                        ui.columns(1, |c| {
+                            c[0].with_layout(
+                                egui::Layout::top_down(egui::Align::Center),
+                                |ui| {
+                                    ui.label(ARROW_CONTROLS);
+                                },
                             );
-                            ui.label(copyright);
+                        });
+                        ui.label(MODIFIER_KEYS);
+                        ui.label("");
+                        ui.label(VI_KEYS_TEXT);
+                        ui.label("");
+                        ui.columns(1, |c| {
+                            c[0].with_layout(
+                                egui::Layout::top_down(egui::Align::Center),
+                                |ui| {
+                                    ui.label(VI_KEYS_CONTROLS);
+                                },
+                            );
+                        });
+                        ui.label(CONTROLS_FOOTER);
+                        ui.label("");
+                        ui.label(CONTROLLER);
+                    }
 
-                            ui.label("");
-                            ui.label(CODE_LICENSE_BLOCK);
-                            ui.hyperlink(AGPL_URL);
-                            ui.label("");
-                            ui.label(THIRD_PARTY_CODE_LICENSE);
-                            ui.label("");
+                    Page::HowToPlay => {
+                        ui.label(HOW_TO_PLAY);
+                    }
 
-                            if !crate::metadata::GIT_HASH.trim().is_empty() {
-                                ui.label(format!("Git commit: {}", crate::metadata::GIT_HASH));
-                            }
+                    Page::Legend => {
+                        ui.label(LEGEND);
+                    }
 
-			    let features = crate::metadata::FEATURES.replace(":", "\n* ");
+                    Page::Credits => {
+                        ui.hyperlink_to(CREDITS_DEV, TOMAS_URL);
+                        ui.label(copyright);
+                        ui.label(CODE_LICENSE_ONELINE);
+                        ui.label("");
+                        ui.hyperlink_to(CREDITS_TILES, VEXED_URL);
+                        ui.label(TILES_LICENSE);
+                        ui.label("");
+                        ui.hyperlink_to(CREDITS_FONT, MONONOKI_URL);
+                        ui.label(FONT_LICENSE);
+                        ui.label("");
+                        ui.label(CREDITS_MUSIC);
+                    }
 
-			    let configs = crate::metadata::CONFIGS.replace(":", "\n* ");
+                    Page::About => {
+                        let version = format!(
+                            "{} version: {}",
+                            crate::metadata::TITLE,
+                            crate::metadata::VERSION
+                        );
 
-			    ui.label(format!("Build profile: {}\nOptimisation level: {}\n\nBuild features: \n* {features}\n\nBuild configs: \n* {configs}\n\n", crate::metadata::PROFILE, crate::metadata::OPT_LEVEL));
+                        ui.label(version);
+                        ui.hyperlink_to(
+                            format!("Homepage: {}", crate::metadata::HOMEPAGE),
+                            crate::metadata::HOMEPAGE,
+                        );
+                        ui.label(copyright);
+
+                        ui.label("");
+                        ui.label(CODE_LICENSE_BLOCK);
+                        ui.hyperlink(AGPL_URL);
+                        ui.label("");
+                        ui.label(THIRD_PARTY_CODE_LICENSE);
+                        ui.label("");
+
+                        if !crate::metadata::GIT_HASH.trim().is_empty() {
+                            ui.label(format!("Git commit: {}", crate::metadata::GIT_HASH));
                         }
-                    };
 
-		    // This hack forces the contents to occupy the full width of the window
-		    // and put the scrollbars as far right as possible.
-		    ui.columns(1, |c| {
-			c[0].with_layout(egui::Layout::top_down(egui::Align::Center), |_| {},
-			);
-		    });
-                });
+			let features = crate::metadata::FEATURES.replace(":", "\n* ");
+
+			let configs = crate::metadata::CONFIGS.replace(":", "\n* ");
+
+			ui.label(format!("Build profile: {}\nOptimisation level: {}\n\nBuild features: \n* {features}\n\nBuild configs: \n* {configs}\n\n", crate::metadata::PROFILE, crate::metadata::OPT_LEVEL));
+                    }
+                };
+
+		// This hack forces the contents to occupy the full width of the window
+		// and put the scrollbars as far right as possible.
+		ui.columns(1, |c| {
+		    c[0].with_layout(egui::Layout::top_down(egui::Align::Center), |_| {},
+		    );
+		});
+            });
 
             // TODO: looks like the separator is no longer being rendered??
             // NOTE: on linux, the separator is visible but super thin, almost invisible

--- a/src/windows/help.rs
+++ b/src/windows/help.rs
@@ -341,6 +341,13 @@ pub fn process(
 			    ui.label(format!("Build profile: {}\nOptimisation level: {}\n\nBuild features: \n* {features}\n\nBuild configs: \n* {configs}\n\n", crate::metadata::PROFILE, crate::metadata::OPT_LEVEL));
                         }
                     };
+
+		    // This hack forces the contents to occupy the full width of the window
+		    // and put the scrollbars as far right as possible.
+		    ui.columns(1, |c| {
+			c[0].with_layout(egui::Layout::top_down(egui::Align::Center), |_| {},
+			);
+		    });
                 });
 
             // TODO: looks like the separator is no longer being rendered??

--- a/src/windows/help.rs
+++ b/src/windows/help.rs
@@ -224,9 +224,7 @@ pub fn process(
         .show(ui.ctx(), |ui| {
             ScrollArea::vertical()
                 .max_height(window_size_px[1])
-				// NOTE: the factor of `50` just feels like a good scrolling distance
-                .scroll_offset((state.help_starting_line * 50) as f32)
-                .show(ui, |ui| {
+		.show(ui, |ui| {
                     // NOTE: HACK: the 7px value hides the scrollbar on contents that doesn't overflow.
                     ui.set_min_height(window_size_px[1] - 7.0);
                     let copyright = format!("Copyright 2013-2024 {}", crate::metadata::AUTHORS);

--- a/src/windows/help.rs
+++ b/src/windows/help.rs
@@ -216,8 +216,6 @@ pub fn process(
     ];
     let window_pos_px = [(screen_size_px.x as f32 - window_size_px[0]) / 2.0, 100.0];
 
-    let scroll_delta = ui.ctx().input().scroll_delta;
-
     egui::Window::new(format!("{}", state.current_help_window))
         .open(&mut visible)
         .collapsible(false)
@@ -226,17 +224,6 @@ pub fn process(
         .show(ui.ctx(), |ui| {
             let scroll_area = ScrollArea::vertical()
                 .max_height(window_size_px[1]);
-	    let scroll_area = if scroll_delta == egui::Vec2::ZERO {
-		match state.help_starting_line {
-		    Some(starting_line) => {
-			scroll_area.scroll_offset((starting_line * 50) as f32)
-		    }
-		    None => scroll_area
-		}
-	    } else {
-		state.help_starting_line = None;
-		scroll_area
-	    };
 	    scroll_area.show(ui, |ui| {
                 // NOTE: HACK: the 7px value hides the scrollbar on contents that doesn't overflow.
                 ui.set_min_height(window_size_px[1] - 7.0);
@@ -408,7 +395,6 @@ pub fn process(
                     .next()
                     .unwrap_or(state.current_help_window);
                 state.current_help_window = new_help_window;
-                state.help_starting_line = None;
             }
 
             Action::PrevPage => {
@@ -417,20 +403,14 @@ pub fn process(
                     .prev()
                     .unwrap_or(state.current_help_window);
                 state.current_help_window = new_help_window;
-                state.help_starting_line = None;
             }
 
             Action::LineUp => {
-                if let Some(ref mut starting_line) = state.help_starting_line {
-                    if *starting_line > 0 {
-                        *starting_line -= 1;
-                    }
-                };
+                state.keyboard_scroll_delta[1] = 50.0;
             }
 
             Action::LineDown => {
-                let prev_line = state.help_starting_line.unwrap_or(0);
-                state.help_starting_line = Some(prev_line + 1);
+                state.keyboard_scroll_delta[1] = -50.0;
             }
 
             Action::Close => {

--- a/src/windows/help.rs
+++ b/src/windows/help.rs
@@ -237,111 +237,111 @@ pub fn process(
 		state.help_starting_line = None;
 		scroll_area
 	    };
-	    scroll_area.show(ui, |ui| {
-                // NOTE: HACK: the 7px value hides the scrollbar on contents that doesn't overflow.
-                ui.set_min_height(window_size_px[1] - 7.0);
-                let copyright = format!("Copyright 2013-2024 {}", crate::metadata::AUTHORS);
-                match state.current_help_window {
-                    Page::DoseResponse => {
-                        ui.label(OVERVIEW);
-                    }
-
-                    Page::Controls => {
-                        ui.label(CONTROLS_HEADER);
-                        ui.label(NUMPAD_TEXT);
-                        ui.label("");
-                        // NOTE: this is a hack for not having a
-                        // way to center a label but it works:
-                        ui.columns(1, |c| {
-                            c[0].with_layout(
-                                egui::Layout::top_down(egui::Align::Center),
-                                |ui| {
-                                    ui.label(NUMPAD_CONTROLS);
-                                },
-                            );
-                        });
-                        ui.label(ARROW_TEXT);
-                        ui.label("");
-                        ui.columns(1, |c| {
-                            c[0].with_layout(
-                                egui::Layout::top_down(egui::Align::Center),
-                                |ui| {
-                                    ui.label(ARROW_CONTROLS);
-                                },
-                            );
-                        });
-                        ui.label(MODIFIER_KEYS);
-                        ui.label("");
-                        ui.label(VI_KEYS_TEXT);
-                        ui.label("");
-                        ui.columns(1, |c| {
-                            c[0].with_layout(
-                                egui::Layout::top_down(egui::Align::Center),
-                                |ui| {
-                                    ui.label(VI_KEYS_CONTROLS);
-                                },
-                            );
-                        });
-                        ui.label(CONTROLS_FOOTER);
-                        ui.label("");
-                        ui.label(CONTROLLER);
-                    }
-
-                    Page::HowToPlay => {
-                        ui.label(HOW_TO_PLAY);
-                    }
-
-                    Page::Legend => {
-                        ui.label(LEGEND);
-                    }
-
-                    Page::Credits => {
-                        ui.hyperlink_to(CREDITS_DEV, TOMAS_URL);
-                        ui.label(copyright);
-                        ui.label(CODE_LICENSE_ONELINE);
-                        ui.label("");
-                        ui.hyperlink_to(CREDITS_TILES, VEXED_URL);
-                        ui.label(TILES_LICENSE);
-                        ui.label("");
-                        ui.hyperlink_to(CREDITS_FONT, MONONOKI_URL);
-                        ui.label(FONT_LICENSE);
-                        ui.label("");
-                        ui.label(CREDITS_MUSIC);
-                    }
-
-                    Page::About => {
-                        let version = format!(
-                            "{} version: {}",
-                            crate::metadata::TITLE,
-                            crate::metadata::VERSION
-                        );
-
-                        ui.label(version);
-                        ui.hyperlink_to(
-                            format!("Homepage: {}", crate::metadata::HOMEPAGE),
-                            crate::metadata::HOMEPAGE,
-                        );
-                        ui.label(copyright);
-
-                        ui.label("");
-                        ui.label(CODE_LICENSE_BLOCK);
-                        ui.hyperlink(AGPL_URL);
-                        ui.label("");
-                        ui.label(THIRD_PARTY_CODE_LICENSE);
-                        ui.label("");
-
-                        if !crate::metadata::GIT_HASH.trim().is_empty() {
-                            ui.label(format!("Git commit: {}", crate::metadata::GIT_HASH));
+		scroll_area.show(ui, |ui| {
+                    // NOTE: HACK: the 7px value hides the scrollbar on contents that doesn't overflow.
+                    ui.set_min_height(window_size_px[1] - 7.0);
+                    let copyright = format!("Copyright 2013-2024 {}", crate::metadata::AUTHORS);
+                    match state.current_help_window {
+                        Page::DoseResponse => {
+                            ui.label(OVERVIEW);
                         }
 
-			let features = crate::metadata::FEATURES.replace(":", "\n* ");
+                        Page::Controls => {
+                            ui.label(CONTROLS_HEADER);
+                            ui.label(NUMPAD_TEXT);
+                            ui.label("");
+                            // NOTE: this is a hack for not having a
+                            // way to center a label but it works:
+                            ui.columns(1, |c| {
+                                c[0].with_layout(
+                                    egui::Layout::top_down(egui::Align::Center),
+                                    |ui| {
+                                        ui.label(NUMPAD_CONTROLS);
+                                    },
+                                );
+                            });
+                            ui.label(ARROW_TEXT);
+                            ui.label("");
+                            ui.columns(1, |c| {
+                                c[0].with_layout(
+                                    egui::Layout::top_down(egui::Align::Center),
+                                    |ui| {
+                                        ui.label(ARROW_CONTROLS);
+                                    },
+                                );
+                            });
+                            ui.label(MODIFIER_KEYS);
+                            ui.label("");
+                            ui.label(VI_KEYS_TEXT);
+                            ui.label("");
+                            ui.columns(1, |c| {
+                                c[0].with_layout(
+                                    egui::Layout::top_down(egui::Align::Center),
+                                    |ui| {
+                                        ui.label(VI_KEYS_CONTROLS);
+                                    },
+                                );
+                            });
+                            ui.label(CONTROLS_FOOTER);
+                            ui.label("");
+                            ui.label(CONTROLLER);
+                        }
 
-			let configs = crate::metadata::CONFIGS.replace(":", "\n* ");
+                        Page::HowToPlay => {
+                            ui.label(HOW_TO_PLAY);
+                        }
 
-			ui.label(format!("Build profile: {}\nOptimisation level: {}\n\nBuild features: \n* {features}\n\nBuild configs: \n* {configs}\n\n", crate::metadata::PROFILE, crate::metadata::OPT_LEVEL));
-                    }
-                };
-            });
+                        Page::Legend => {
+                            ui.label(LEGEND);
+                        }
+
+                        Page::Credits => {
+                            ui.hyperlink_to(CREDITS_DEV, TOMAS_URL);
+                            ui.label(copyright);
+                            ui.label(CODE_LICENSE_ONELINE);
+                            ui.label("");
+                            ui.hyperlink_to(CREDITS_TILES, VEXED_URL);
+                            ui.label(TILES_LICENSE);
+                            ui.label("");
+                            ui.hyperlink_to(CREDITS_FONT, MONONOKI_URL);
+                            ui.label(FONT_LICENSE);
+                            ui.label("");
+                            ui.label(CREDITS_MUSIC);
+                        }
+
+                        Page::About => {
+                            let version = format!(
+                                "{} version: {}",
+                                crate::metadata::TITLE,
+                                crate::metadata::VERSION
+                            );
+
+                            ui.label(version);
+                            ui.hyperlink_to(
+                                format!("Homepage: {}", crate::metadata::HOMEPAGE),
+                                crate::metadata::HOMEPAGE,
+                            );
+                            ui.label(copyright);
+
+                            ui.label("");
+                            ui.label(CODE_LICENSE_BLOCK);
+                            ui.hyperlink(AGPL_URL);
+                            ui.label("");
+                            ui.label(THIRD_PARTY_CODE_LICENSE);
+                            ui.label("");
+
+                            if !crate::metadata::GIT_HASH.trim().is_empty() {
+                                ui.label(format!("Git commit: {}", crate::metadata::GIT_HASH));
+                            }
+
+			    let features = crate::metadata::FEATURES.replace(":", "\n* ");
+
+			    let configs = crate::metadata::CONFIGS.replace(":", "\n* ");
+
+			    ui.label(format!("Build profile: {}\nOptimisation level: {}\n\nBuild features: \n* {features}\n\nBuild configs: \n* {configs}\n\n", crate::metadata::PROFILE, crate::metadata::OPT_LEVEL));
+                        }
+                    };
+                });
 
             // TODO: looks like the separator is no longer being rendered??
             // NOTE: on linux, the separator is visible but super thin, almost invisible

--- a/src/windows/help.rs
+++ b/src/windows/help.rs
@@ -216,119 +216,132 @@ pub fn process(
     ];
     let window_pos_px = [(screen_size_px.x as f32 - window_size_px[0]) / 2.0, 100.0];
 
+    let scroll_delta = ui.ctx().input().scroll_delta;
+
     egui::Window::new(format!("{}", state.current_help_window))
         .open(&mut visible)
         .collapsible(false)
         .fixed_pos(window_pos_px)
         .fixed_size(window_size_px)
         .show(ui.ctx(), |ui| {
-            ScrollArea::vertical()
-                .max_height(window_size_px[1])
-		.show(ui, |ui| {
-                    // NOTE: HACK: the 7px value hides the scrollbar on contents that doesn't overflow.
-                    ui.set_min_height(window_size_px[1] - 7.0);
-                    let copyright = format!("Copyright 2013-2024 {}", crate::metadata::AUTHORS);
-                    match state.current_help_window {
-                        Page::DoseResponse => {
-                            ui.label(OVERVIEW);
-                        }
+            let scroll_area = ScrollArea::vertical()
+                .max_height(window_size_px[1]);
+	    let scroll_area = if scroll_delta == egui::Vec2::ZERO {
+		match state.help_starting_line {
+		    Some(starting_line) => {
+			scroll_area.scroll_offset((starting_line * 50) as f32)
+		    }
+		    None => scroll_area
+		}
+	    } else {
+		state.help_starting_line = None;
+		scroll_area
+	    };
+	    scroll_area.show(ui, |ui| {
+                // NOTE: HACK: the 7px value hides the scrollbar on contents that doesn't overflow.
+                ui.set_min_height(window_size_px[1] - 7.0);
+                let copyright = format!("Copyright 2013-2024 {}", crate::metadata::AUTHORS);
+                match state.current_help_window {
+                    Page::DoseResponse => {
+                        ui.label(OVERVIEW);
+                    }
 
-                        Page::Controls => {
-                            ui.label(CONTROLS_HEADER);
-                            ui.label(NUMPAD_TEXT);
-                            ui.label("");
-                            // NOTE: this is a hack for not having a
-                            // way to center a label but it works:
-                            ui.columns(1, |c| {
-                                c[0].with_layout(
-                                    egui::Layout::top_down(egui::Align::Center),
-                                    |ui| {
-                                        ui.label(NUMPAD_CONTROLS);
-                                    },
-                                );
-                            });
-                            ui.label(ARROW_TEXT);
-                            ui.label("");
-                            ui.columns(1, |c| {
-                                c[0].with_layout(
-                                    egui::Layout::top_down(egui::Align::Center),
-                                    |ui| {
-                                        ui.label(ARROW_CONTROLS);
-                                    },
-                                );
-                            });
-                            ui.label(MODIFIER_KEYS);
-                            ui.label("");
-                            ui.label(VI_KEYS_TEXT);
-                            ui.label("");
-                            ui.columns(1, |c| {
-                                c[0].with_layout(
-                                    egui::Layout::top_down(egui::Align::Center),
-                                    |ui| {
-                                        ui.label(VI_KEYS_CONTROLS);
-                                    },
-                                );
-                            });
-                            ui.label(CONTROLS_FOOTER);
-                            ui.label("");
-                            ui.label(CONTROLLER);
-                        }
-
-                        Page::HowToPlay => {
-                            ui.label(HOW_TO_PLAY);
-                        }
-
-                        Page::Legend => {
-                            ui.label(LEGEND);
-                        }
-
-                        Page::Credits => {
-                            ui.hyperlink_to(CREDITS_DEV, TOMAS_URL);
-                            ui.label(copyright);
-                            ui.label(CODE_LICENSE_ONELINE);
-                            ui.label("");
-                            ui.hyperlink_to(CREDITS_TILES, VEXED_URL);
-                            ui.label(TILES_LICENSE);
-                            ui.label("");
-                            ui.hyperlink_to(CREDITS_FONT, MONONOKI_URL);
-                            ui.label(FONT_LICENSE);
-                            ui.label("");
-                            ui.label(CREDITS_MUSIC);
-                        }
-
-                        Page::About => {
-                            let version = format!(
-                                "{} version: {}",
-                                crate::metadata::TITLE,
-                                crate::metadata::VERSION
+                    Page::Controls => {
+                        ui.label(CONTROLS_HEADER);
+                        ui.label(NUMPAD_TEXT);
+                        ui.label("");
+                        // NOTE: this is a hack for not having a
+                        // way to center a label but it works:
+                        ui.columns(1, |c| {
+                            c[0].with_layout(
+                                egui::Layout::top_down(egui::Align::Center),
+                                |ui| {
+                                    ui.label(NUMPAD_CONTROLS);
+                                },
                             );
-
-                            ui.label(version);
-                            ui.hyperlink_to(
-                                format!("Homepage: {}", crate::metadata::HOMEPAGE),
-                                crate::metadata::HOMEPAGE,
+                        });
+                        ui.label(ARROW_TEXT);
+                        ui.label("");
+                        ui.columns(1, |c| {
+                            c[0].with_layout(
+                                egui::Layout::top_down(egui::Align::Center),
+                                |ui| {
+                                    ui.label(ARROW_CONTROLS);
+                                },
                             );
-                            ui.label(copyright);
+                        });
+                        ui.label(MODIFIER_KEYS);
+                        ui.label("");
+                        ui.label(VI_KEYS_TEXT);
+                        ui.label("");
+                        ui.columns(1, |c| {
+                            c[0].with_layout(
+                                egui::Layout::top_down(egui::Align::Center),
+                                |ui| {
+                                    ui.label(VI_KEYS_CONTROLS);
+                                },
+                            );
+                        });
+                        ui.label(CONTROLS_FOOTER);
+                        ui.label("");
+                        ui.label(CONTROLLER);
+                    }
 
-                            ui.label("");
-                            ui.label(CODE_LICENSE_BLOCK);
-                            ui.hyperlink(AGPL_URL);
-                            ui.label("");
-                            ui.label(THIRD_PARTY_CODE_LICENSE);
-                            ui.label("");
+                    Page::HowToPlay => {
+                        ui.label(HOW_TO_PLAY);
+                    }
 
-                            if !crate::metadata::GIT_HASH.trim().is_empty() {
-                                ui.label(format!("Git commit: {}", crate::metadata::GIT_HASH));
-                            }
+                    Page::Legend => {
+                        ui.label(LEGEND);
+                    }
 
-			    let features = crate::metadata::FEATURES.replace(":", "\n* ");
+                    Page::Credits => {
+                        ui.hyperlink_to(CREDITS_DEV, TOMAS_URL);
+                        ui.label(copyright);
+                        ui.label(CODE_LICENSE_ONELINE);
+                        ui.label("");
+                        ui.hyperlink_to(CREDITS_TILES, VEXED_URL);
+                        ui.label(TILES_LICENSE);
+                        ui.label("");
+                        ui.hyperlink_to(CREDITS_FONT, MONONOKI_URL);
+                        ui.label(FONT_LICENSE);
+                        ui.label("");
+                        ui.label(CREDITS_MUSIC);
+                    }
 
-			    let configs = crate::metadata::CONFIGS.replace(":", "\n* ");
+                    Page::About => {
+                        let version = format!(
+                            "{} version: {}",
+                            crate::metadata::TITLE,
+                            crate::metadata::VERSION
+                        );
 
-			    ui.label(format!("Build profile: {}\nOptimisation level: {}\n\nBuild features: \n* {features}\n\nBuild configs: \n* {configs}\n\n", crate::metadata::PROFILE, crate::metadata::OPT_LEVEL));
+                        ui.label(version);
+                        ui.hyperlink_to(
+                            format!("Homepage: {}", crate::metadata::HOMEPAGE),
+                            crate::metadata::HOMEPAGE,
+                        );
+                        ui.label(copyright);
+
+                        ui.label("");
+                        ui.label(CODE_LICENSE_BLOCK);
+                        ui.hyperlink(AGPL_URL);
+                        ui.label("");
+                        ui.label(THIRD_PARTY_CODE_LICENSE);
+                        ui.label("");
+
+                        if !crate::metadata::GIT_HASH.trim().is_empty() {
+                            ui.label(format!("Git commit: {}", crate::metadata::GIT_HASH));
                         }
-                    };
-                });
+
+			let features = crate::metadata::FEATURES.replace(":", "\n* ");
+
+			let configs = crate::metadata::CONFIGS.replace(":", "\n* ");
+
+			ui.label(format!("Build profile: {}\nOptimisation level: {}\n\nBuild features: \n* {features}\n\nBuild configs: \n* {configs}\n\n", crate::metadata::PROFILE, crate::metadata::OPT_LEVEL));
+                    }
+                };
+            });
 
             // TODO: looks like the separator is no longer being rendered??
             // NOTE: on linux, the separator is visible but super thin, almost invisible
@@ -388,7 +401,7 @@ pub fn process(
                     .next()
                     .unwrap_or(state.current_help_window);
                 state.current_help_window = new_help_window;
-                state.help_starting_line = 0;
+                state.help_starting_line = None;
             }
 
             Action::PrevPage => {
@@ -397,16 +410,21 @@ pub fn process(
                     .prev()
                     .unwrap_or(state.current_help_window);
                 state.current_help_window = new_help_window;
-                state.help_starting_line = 0;
+                state.help_starting_line = None;
             }
 
             Action::LineUp => {
-                if state.help_starting_line > 0 {
-                    state.help_starting_line -= 1;
-                }
+                if let Some(ref mut starting_line) = state.help_starting_line {
+                    if *starting_line > 0 {
+                        *starting_line -= 1;
+                    }
+                };
             }
 
-            Action::LineDown => state.help_starting_line += 1,
+            Action::LineDown => {
+                let prev_line = state.help_starting_line.unwrap_or(0);
+                state.help_starting_line = Some(prev_line + 1);
+            }
 
             Action::Close => {
                 state.window_stack.pop();


### PR DESCRIPTION
The mouse scrolling was not working. This now fixes it, but the original mechanism had bad interaction between mouse and keyboard scrolling. The naive implementation was either or.

In the end, the keyboard presses now generate `RawInput.scroll_delta` that gets passed to egui -- just like the mouse's scroll button does. And that seems to work perfectly.