### PR TITLE
ci: update actions/checkout and aws-actions/configure-aws-credentials to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,12 +44,12 @@ jobs:
       RUSTFLAGS: -D warnings
     steps:
     - name: Check out the Dose Response repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Install build-time dependencies
       run: |
         ${{ matrix.platform.build_time_dependencies }}
     - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@v1
+      uses: aws-actions/configure-aws-credentials@v4
       with:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
We're a few versions behind, good to try to bring them up-to-date.