### PR TITLE
Set a name to the GitHub Action build strategy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   build:
+    name: ${{ matrix.platform.os }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Right now, GHA names the jobs based on the full values of the matrix. I suspect that this is what's preventing us from adding the Ubuntu one as a required job.

Because Github's kind of being tripped by the fact that the job is too large. Let's see if this actually works. Even if it doesn't fix this particular issue, I'd still keep it if it gets the names shorter in the UI.