### PR TITLE
Upgrade GitHub Actions to the `windows-2025` runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
           build_time_dependencies: |
             sudo apt-get update
             sudo apt-get install libasound2-dev libudev-dev libfontconfig-dev
-        - os: windows-2022
+        - os: windows-2025
           extra_features: windows-extra-features
           build_time_dependencies: ""
         # NOTE: `macos-latest` uses the Arm64 architecture:


### PR DESCRIPTION
The old (`windows-2022`) one is having trouble compiling SDL3 and the issue was closed as won't fix with it working in the `windows-2025` runner.

https://github.com/libsdl-org/SDL/issues/11487